### PR TITLE
Quieten down gogpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ $ gpm install
 ## Goals
  * Keep things small and simple
  * Try to use `go get` wherever possible
- * No external dependencies
  * Use Go's own logic for package import path resolution (the vcs package code is from Go 1.2.2)
  * Don't replicate any functionality of `go get`
 

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -33,7 +32,7 @@ func bootstrap(packages []string) error {
 		return errors.New("A Godeps file already exists within this directory")
 	}
 
-	log.Println("Installing dependencies")
+	logVerbose.Println("Installing dependencies")
 
 	// go get dependencies if they're not already present (without updating)
 	_, err := execCmd("go", append([]string{"get", "-d"}, packages...)...)
@@ -96,17 +95,17 @@ func bootstrap(packages []string) error {
 			return err
 		}
 
-		log.Printf(`Adding package "%s" version "%s"`, pkg.RootImportPath(), version)
+		logVerbose.Printf(`Adding package "%s" version "%s"`, pkg.RootImportPath(), version)
 		deps[pkg.RootImportPath()] = version
 	}
 
-	log.Printf("Writing Godeps file")
+	logVerbose.Printf("Writing Godeps file")
 	err = writeDepFile(deps)
 	if err != nil {
 		return err
 	}
 
-	log.Println("All Done")
+	logVerbose.Println("All Done")
 
 	return nil
 }

--- a/install.go
+++ b/install.go
@@ -1,10 +1,6 @@
 package main
 
-import (
-	"log"
-
-	"github.com/mtibben/gogpm/vcs"
-)
+import "github.com/mtibben/gogpm/vcs"
 
 func goget(dep string) (string, error) {
 	return execCmd("go", "get", "-d", "-u", dep)
@@ -25,10 +21,10 @@ func install() error {
 		}
 
 		if pkg.IsCurrentTagOrRevision(wantedVersion) {
-			log.Printf("Checked %s\n", dep)
+			logVerbose.Printf("Checked %s\n", dep)
 		} else {
 
-			log.Printf("Getting %s\n", dep)
+			logVerbose.Printf("Getting %s\n", dep)
 
 			// we need the /... else sometimes we get
 			// 	   imports github.com/bradfitz/gomemcache: no buildable Go source files in /go/src/github.com/bradfitz/gomemcache
@@ -44,7 +40,7 @@ func install() error {
 				}
 			}
 
-			log.Printf("Setting %s to %s\n", dep, wantedVersion)
+			logVerbose.Printf("Setting %s to %s\n", dep, wantedVersion)
 
 			err = pkg.SetRevision(wantedVersion)
 			if err != nil {
@@ -53,7 +49,7 @@ func install() error {
 		}
 	}
 
-	log.Println("All Done")
+	logVerbose.Println("All Done")
 
 	return nil
 }

--- a/util.go
+++ b/util.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"log"
 	"os/exec"
 )
 
@@ -15,8 +14,8 @@ func execCmd(cmdname string, cmdargs ...string) (string, error) {
 
 	err := command.Run()
 	if err != nil {
-		log.Printf("Error while executing: %s %v\n", cmdname, cmdargs)
-		log.Println(out.String())
+		logErr.Printf("Error while executing: %s %v\n", cmdname, cmdargs)
+		logErr.Println(out.String())
 		return out.String(), err
 	}
 


### PR DESCRIPTION
Adhere to the principle that "silence is golden".

This adds a verbose logger and an error logger. By default, verbosity is off
