### PR TITLE
Cleaner handling of PackageRepo Dir()

### DIFF
--- a/vcs/gogpm.go
+++ b/vcs/gogpm.go
@@ -56,7 +56,7 @@ func (v *vcsCmd) checkout(dir, tag string) error {
 
 type PackageRepo struct {
 	rr  *repoRoot
-	ctx *build.Context
+	ctx build.Context
 }
 
 func PackageForImportPath(importPath string) (*PackageRepo, error) {
@@ -66,7 +66,8 @@ func PackageForImportPath(importPath string) (*PackageRepo, error) {
 	}
 
 	return &PackageRepo{
-		rr: reporoot,
+		rr:  reporoot,
+		ctx: build.Default,
 	}, nil
 }
 
@@ -77,7 +78,7 @@ func (p *PackageRepo) RootImportPath() string {
 func (p *PackageRepo) Dir() string {
 	// get go/build to search GOPATH for where it is installed
 	pwd, _ := os.Getwd()
-	pkg, err := p.ImportContext().Import(p.rr.root, pwd, build.FindOnly)
+	pkg, err := p.ctx.Import(p.rr.root, pwd, build.FindOnly)
 	if err == nil {
 		return pkg.Dir
 	}
@@ -85,7 +86,7 @@ func (p *PackageRepo) Dir() string {
 	// we should add a check for if the err is a build.MultiplePackageError
 
 	// if uninstalled go get/gogpm will put in first GOPATH entry
-	goPath := p.ImportContext().GOPATH
+	goPath := p.ctx.GOPATH
 	paths := strings.Split(goPath, ":")
 
 	if len(paths) == 0 {
@@ -125,14 +126,6 @@ func (p *PackageRepo) CurrentTagOrRevision() (string, error) {
 		return currentTag, nil
 	} else {
 		return currentRev, nil
-	}
-}
-
-func (p *PackageRepo) ImportContext() *build.Context {
-	if p.ctx != nil {
-		return p.ctx
-	} else {
-		return &build.Default
 	}
 }
 

--- a/vcs/gogpm.go
+++ b/vcs/gogpm.go
@@ -82,6 +82,7 @@ func (p *PackageRepo) Dir() string {
 	if err == nil {
 		return pkg.Dir
 	}
+
 	// TODO when ready to drop support for go 1.3 & under
 	// we should add a check for if the err is a build.MultiplePackageError
 

--- a/vcs/gogpm_test.go
+++ b/vcs/gogpm_test.go
@@ -1,7 +1,6 @@
 package vcs
 
 import (
-	"go/build"
 	"io/ioutil"
 	"os"
 	"path"
@@ -12,9 +11,7 @@ import (
 func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 	withDummyBuildContextSingleGopath(t, func(gopath string) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
-		context := build.Default
-		context.GOPATH = gopath
-		repo.ctx = &context
+		repo.ctx.GOPATH = gopath
 
 		expected := path.Join(gopath, "src", "/github.com/fake/library")
 		actual := repo.Dir()
@@ -27,9 +24,7 @@ func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 func TestNotYetInstalledPackageRepoSimpleGopath(t *testing.T) {
 	withDummyBuildContextSingleGopath(t, func(gopath string) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
-		context := build.Default
-		context.GOPATH = gopath
-		repo.ctx = &context
+		repo.ctx.GOPATH = gopath
 
 		expected := path.Join(gopath, "src", "/github.com/fake/uninstalledlibrary")
 		actual := repo.Dir()
@@ -60,9 +55,7 @@ func withDummyBuildContextSingleGopath(t *testing.T, testFunc func(string)) {
 func TestMultipleGopathSingleInstall(t *testing.T) {
 	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
-		context := build.Default
-		context.GOPATH = strings.Join([]string{gopathOne, gopathTwo}, ":")
-		repo.ctx = &context
+		repo.ctx.GOPATH = strings.Join([]string{gopathOne, gopathTwo}, ":")
 
 		expected := path.Join(gopathTwo, "src", "/github.com/fake/library")
 		actual := repo.Dir()
@@ -75,9 +68,7 @@ func TestMultipleGopathSingleInstall(t *testing.T) {
 func TestMultipleGopathNoInstall(t *testing.T) {
 	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
-		context := build.Default
-		context.GOPATH = strings.Join([]string{gopathOne, gopathTwo}, ":")
-		repo.ctx = &context
+		repo.ctx.GOPATH = strings.Join([]string{gopathOne, gopathTwo}, ":")
 
 		expected := path.Join(gopathOne, "src", "/github.com/fake/uninstalledlibrary")
 		actual := repo.Dir()

--- a/vcs/gogpm_test.go
+++ b/vcs/gogpm_test.go
@@ -1,0 +1,50 @@
+package vcs
+
+import (
+	"go/build"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestPresentPackageRepoSimpleGopath(t *testing.T) {
+	withDummyBuildContext(t, func(gopath string) {
+		repo, _ := PackageForImportPath("github.com/fake/library")
+		expected := path.Join(gopath, "src", "/github.com/fake/library")
+		actual := repo.Dir()
+		if actual != expected {
+			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
+		}
+	})
+}
+
+func TestNotYetInstalledPackageRepoSimpleGopath(t *testing.T) {
+	withDummyBuildContext(t, func(gopath string) {
+		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
+		expected := path.Join(gopath, "src", "/github.com/fake/uninstalledlibrary")
+		actual := repo.Dir()
+		if actual != expected {
+			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
+		}
+	})
+}
+
+func withDummyBuildContext(t *testing.T, testFunc func(string)) {
+	fakeGoPath, err := ioutil.TempDir("", "gopath")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.MkdirAll(path.Join(fakeGoPath, "src/github.com/fake/library"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	context := build.Default
+	context.GOPATH = fakeGoPath
+	importContext = &context
+
+	testFunc(fakeGoPath)
+
+	importContext = nil
+}

--- a/vcs/gogpm_test.go
+++ b/vcs/gogpm_test.go
@@ -1,6 +1,7 @@
 package vcs
 
 import (
+	"go/build"
 	"io/ioutil"
 	"os"
 	"path"
@@ -11,7 +12,7 @@ import (
 func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 	withDummyBuildContextSingleGopath(t, func(gopath string) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
-		repo.ctx.GOPATH = gopath
+		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
 		expected := path.Join(gopath, "src", "/github.com/fake/library")
 		actual := repo.Dir()
@@ -24,7 +25,7 @@ func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 func TestNotYetInstalledPackageRepoSimpleGopath(t *testing.T) {
 	withDummyBuildContextSingleGopath(t, func(gopath string) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
-		repo.ctx.GOPATH = gopath
+		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
 		expected := path.Join(gopath, "src", "/github.com/fake/uninstalledlibrary")
 		actual := repo.Dir()
@@ -54,7 +55,8 @@ func withDummyBuildContextSingleGopath(t *testing.T, testFunc func(string)) {
 func TestMultipleGopathSingleInstall(t *testing.T) {
 	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
-		repo.ctx.GOPATH = strings.Join([]string{gopathOne, gopathTwo}, ":")
+		gopath := strings.Join([]string{gopathOne, gopathTwo}, ":")
+		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
 		expected := path.Join(gopathTwo, "src", "/github.com/fake/library")
 		actual := repo.Dir()
@@ -67,7 +69,8 @@ func TestMultipleGopathSingleInstall(t *testing.T) {
 func TestMultipleGopathNoInstall(t *testing.T) {
 	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
-		repo.ctx.GOPATH = strings.Join([]string{gopathOne, gopathTwo}, ":")
+		gopath := strings.Join([]string{gopathOne, gopathTwo}, ":")
+		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
 		expected := path.Join(gopathOne, "src", "/github.com/fake/uninstalledlibrary")
 		actual := repo.Dir()

--- a/vcs/gogpm_test.go
+++ b/vcs/gogpm_test.go
@@ -5,11 +5,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 )
 
 func TestPresentPackageRepoSimpleGopath(t *testing.T) {
-	withDummyBuildContext(t, func(gopath string) {
+	withDummyBuildContextSingleGopath(t, func(gopath string) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
 		expected := path.Join(gopath, "src", "/github.com/fake/library")
 		actual := repo.Dir()
@@ -20,7 +21,7 @@ func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 }
 
 func TestNotYetInstalledPackageRepoSimpleGopath(t *testing.T) {
-	withDummyBuildContext(t, func(gopath string) {
+	withDummyBuildContextSingleGopath(t, func(gopath string) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
 		expected := path.Join(gopath, "src", "/github.com/fake/uninstalledlibrary")
 		actual := repo.Dir()
@@ -30,7 +31,8 @@ func TestNotYetInstalledPackageRepoSimpleGopath(t *testing.T) {
 	})
 }
 
-func withDummyBuildContext(t *testing.T, testFunc func(string)) {
+func withDummyBuildContextSingleGopath(t *testing.T, testFunc func(string)) {
+	// setup
 	fakeGoPath, err := ioutil.TempDir("", "gopath")
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +46,59 @@ func withDummyBuildContext(t *testing.T, testFunc func(string)) {
 	context.GOPATH = fakeGoPath
 	importContext = &context
 
+	// run test
 	testFunc(fakeGoPath)
 
+	// cleanup
 	importContext = nil
+	os.RemoveAll(fakeGoPath)
+}
+
+func TestMultipleGopathSingleInstall(t *testing.T) {
+	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
+		repo, _ := PackageForImportPath("github.com/fake/library")
+		expected := path.Join(gopathTwo, "src", "/github.com/fake/library")
+		actual := repo.Dir()
+		if actual != expected {
+			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
+		}
+	})
+}
+
+func TestMultipleGopathNoInstall(t *testing.T) {
+	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
+		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
+		expected := path.Join(gopathOne, "src", "/github.com/fake/uninstalledlibrary")
+		actual := repo.Dir()
+		if actual != expected {
+			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
+		}
+	})
+}
+
+func withDummyBuildContextMultipleGopath(t *testing.T, testFunc func(string, string)) {
+	// setup
+	fakeGoPath, err := ioutil.TempDir("", "gopath")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeGoPathTwo, err := ioutil.TempDir("", "gopathtwo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.MkdirAll(path.Join(fakeGoPathTwo, "src/github.com/fake/library"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	context := build.Default
+	context.GOPATH = strings.Join([]string{fakeGoPath, fakeGoPathTwo}, ":")
+	importContext = &context
+
+	// run test
+	testFunc(fakeGoPath, fakeGoPathTwo)
+
+	// cleanup
+	importContext = nil
+	os.RemoveAll(fakeGoPath)
 }

--- a/vcs/gogpm_test.go
+++ b/vcs/gogpm_test.go
@@ -12,6 +12,10 @@ import (
 func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 	withDummyBuildContextSingleGopath(t, func(gopath string) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
+		context := build.Default
+		context.GOPATH = gopath
+		repo.ctx = &context
+
 		expected := path.Join(gopath, "src", "/github.com/fake/library")
 		actual := repo.Dir()
 		if actual != expected {
@@ -23,6 +27,10 @@ func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 func TestNotYetInstalledPackageRepoSimpleGopath(t *testing.T) {
 	withDummyBuildContextSingleGopath(t, func(gopath string) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
+		context := build.Default
+		context.GOPATH = gopath
+		repo.ctx = &context
+
 		expected := path.Join(gopath, "src", "/github.com/fake/uninstalledlibrary")
 		actual := repo.Dir()
 		if actual != expected {
@@ -42,21 +50,20 @@ func withDummyBuildContextSingleGopath(t *testing.T, testFunc func(string)) {
 		t.Fatal(err)
 	}
 
-	context := build.Default
-	context.GOPATH = fakeGoPath
-	importContext = &context
-
 	// run test
 	testFunc(fakeGoPath)
 
 	// cleanup
-	importContext = nil
 	os.RemoveAll(fakeGoPath)
 }
 
 func TestMultipleGopathSingleInstall(t *testing.T) {
 	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
+		context := build.Default
+		context.GOPATH = strings.Join([]string{gopathOne, gopathTwo}, ":")
+		repo.ctx = &context
+
 		expected := path.Join(gopathTwo, "src", "/github.com/fake/library")
 		actual := repo.Dir()
 		if actual != expected {
@@ -68,6 +75,10 @@ func TestMultipleGopathSingleInstall(t *testing.T) {
 func TestMultipleGopathNoInstall(t *testing.T) {
 	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
+		context := build.Default
+		context.GOPATH = strings.Join([]string{gopathOne, gopathTwo}, ":")
+		repo.ctx = &context
+
 		expected := path.Join(gopathOne, "src", "/github.com/fake/uninstalledlibrary")
 		actual := repo.Dir()
 		if actual != expected {
@@ -91,14 +102,9 @@ func withDummyBuildContextMultipleGopath(t *testing.T, testFunc func(string, str
 		t.Fatal(err)
 	}
 
-	context := build.Default
-	context.GOPATH = strings.Join([]string{fakeGoPath, fakeGoPathTwo}, ":")
-	importContext = &context
-
 	// run test
 	testFunc(fakeGoPath, fakeGoPathTwo)
 
 	// cleanup
-	importContext = nil
 	os.RemoveAll(fakeGoPath)
 }

--- a/vcs/gogpm_test.go
+++ b/vcs/gogpm_test.go
@@ -40,8 +40,7 @@ func withDummyBuildContextSingleGopath(t *testing.T, testFunc func(string)) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.MkdirAll(path.Join(fakeGoPath, "src/github.com/fake/library"), 0777)
-	if err != nil {
+	if err = os.MkdirAll(path.Join(fakeGoPath, "src/github.com/fake/library"), 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -88,8 +87,7 @@ func withDummyBuildContextMultipleGopath(t *testing.T, testFunc func(string, str
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.MkdirAll(path.Join(fakeGoPathTwo, "src/github.com/fake/library"), 0777)
-	if err != nil {
+	if err = os.MkdirAll(path.Join(fakeGoPathTwo, "src/github.com/fake/library"), 0777); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Rather than duplicate the search logic that go uses internally through the GOPATH I thought it better to use it directly from the `go/build` package. That approach doesn't work for uninstalled packages, so still needed to manually split GOPATH and pick the first in that case.

Tests could be a bit dryer/neater but I ran out of steam and ideas.