### PR TITLE
Reliability improvements for GOPATH searching

### DIFF
--- a/vcs/gogpm.go
+++ b/vcs/gogpm.go
@@ -5,6 +5,7 @@ import (
 	"go/build"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -91,7 +92,7 @@ func (p *PackageRepo) Dir() string {
 
 	// if uninstalled go get/gogpm will put in first GOPATH entry
 	goPath := p.ctx.GOPATH
-	paths := strings.Split(goPath, ":")
+	paths := filepath.SplitList(goPath)
 
 	if len(paths) == 0 {
 		panic("GOPATH not defined")

--- a/vcs/gogpm.go
+++ b/vcs/gogpm.go
@@ -77,7 +77,10 @@ func (p *PackageRepo) RootImportPath() string {
 
 func (p *PackageRepo) Dir() string {
 	// get go/build to search GOPATH for where it is installed
-	pwd, _ := os.Getwd()
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
 	pkg, err := p.ctx.Import(p.rr.root, pwd, build.FindOnly)
 	if err == nil {
 		return pkg.Dir

--- a/vcs/gogpm.go
+++ b/vcs/gogpm.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"go/build"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -98,7 +97,7 @@ func (p *PackageRepo) Dir() string {
 		panic("GOPATH not defined")
 	}
 
-	return path.Join(paths[0], "src", p.rr.root)
+	return filepath.Join(paths[0], "src", p.rr.root)
 }
 
 // IsCurrentTagOrRevision checks if the given version matches

--- a/vcs/gogpm_test.go
+++ b/vcs/gogpm_test.go
@@ -1,6 +1,7 @@
 package vcs
 
 import (
+	"fmt"
 	"go/build"
 	"io/ioutil"
 	"os"
@@ -14,7 +15,7 @@ func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
 		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
-		expected := path.Join(gopath, "src", "/github.com/fake/library")
+		expected := path.Join(gopath, "src", "github.com", "fake", "library")
 		actual := repo.Dir()
 		if actual != expected {
 			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
@@ -27,7 +28,7 @@ func TestNotYetInstalledPackageRepoSimpleGopath(t *testing.T) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
 		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
-		expected := path.Join(gopath, "src", "/github.com/fake/uninstalledlibrary")
+		expected := path.Join(gopath, "src", "github.com", "fake", "uninstalledlibrary")
 		actual := repo.Dir()
 		if actual != expected {
 			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
@@ -41,7 +42,7 @@ func withDummyBuildContextSingleGopath(t *testing.T, testFunc func(string)) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = os.MkdirAll(path.Join(fakeGoPath, "src/github.com/fake/library"), 0777); err != nil {
+	if err = os.MkdirAll(path.Join(fakeGoPath, "src", "github.com", "fake", "library"), 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -55,10 +56,10 @@ func withDummyBuildContextSingleGopath(t *testing.T, testFunc func(string)) {
 func TestMultipleGopathSingleInstall(t *testing.T) {
 	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
-		gopath := strings.Join([]string{gopathOne, gopathTwo}, ":")
+		gopath := strings.Join([]string{gopathOne, gopathTwo}, fmt.Sprintf("%c", os.PathListSeparator))
 		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
-		expected := path.Join(gopathTwo, "src", "/github.com/fake/library")
+		expected := path.Join(gopathTwo, "src", "github.com", "fake", "library")
 		actual := repo.Dir()
 		if actual != expected {
 			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
@@ -69,10 +70,10 @@ func TestMultipleGopathSingleInstall(t *testing.T) {
 func TestMultipleGopathNoInstall(t *testing.T) {
 	withDummyBuildContextMultipleGopath(t, func(gopathOne string, gopathTwo string) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
-		gopath := strings.Join([]string{gopathOne, gopathTwo}, ":")
+		gopath := strings.Join([]string{gopathOne, gopathTwo}, fmt.Sprintf("%c", os.PathListSeparator))
 		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
-		expected := path.Join(gopathOne, "src", "/github.com/fake/uninstalledlibrary")
+		expected := path.Join(gopathOne, "src", "github.com", "fake", "uninstalledlibrary")
 		actual := repo.Dir()
 		if actual != expected {
 			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
@@ -90,7 +91,7 @@ func withDummyBuildContextMultipleGopath(t *testing.T, testFunc func(string, str
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = os.MkdirAll(path.Join(fakeGoPathTwo, "src/github.com/fake/library"), 0777); err != nil {
+	if err = os.MkdirAll(path.Join(fakeGoPathTwo, "src", "github.com", "fake", "library"), 0777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vcs/gogpm_test.go
+++ b/vcs/gogpm_test.go
@@ -5,7 +5,7 @@ import (
 	"go/build"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -15,7 +15,7 @@ func TestPresentPackageRepoSimpleGopath(t *testing.T) {
 		repo, _ := PackageForImportPath("github.com/fake/library")
 		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
-		expected := path.Join(gopath, "src", "github.com", "fake", "library")
+		expected := filepath.Join(gopath, "src", "github.com", "fake", "library")
 		actual := repo.Dir()
 		if actual != expected {
 			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
@@ -28,7 +28,7 @@ func TestNotYetInstalledPackageRepoSimpleGopath(t *testing.T) {
 		repo, _ := PackageForImportPath("github.com/fake/uninstalledlibrary")
 		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
-		expected := path.Join(gopath, "src", "github.com", "fake", "uninstalledlibrary")
+		expected := filepath.Join(gopath, "src", "github.com", "fake", "uninstalledlibrary")
 		actual := repo.Dir()
 		if actual != expected {
 			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
@@ -42,7 +42,7 @@ func withDummyBuildContextSingleGopath(t *testing.T, testFunc func(string)) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = os.MkdirAll(path.Join(fakeGoPath, "src", "github.com", "fake", "library"), 0777); err != nil {
+	if err = os.MkdirAll(filepath.Join(fakeGoPath, "src", "github.com", "fake", "library"), 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -59,7 +59,7 @@ func TestMultipleGopathSingleInstall(t *testing.T) {
 		gopath := strings.Join([]string{gopathOne, gopathTwo}, fmt.Sprintf("%c", os.PathListSeparator))
 		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
-		expected := path.Join(gopathTwo, "src", "github.com", "fake", "library")
+		expected := filepath.Join(gopathTwo, "src", "github.com", "fake", "library")
 		actual := repo.Dir()
 		if actual != expected {
 			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
@@ -73,7 +73,7 @@ func TestMultipleGopathNoInstall(t *testing.T) {
 		gopath := strings.Join([]string{gopathOne, gopathTwo}, fmt.Sprintf("%c", os.PathListSeparator))
 		repo.ctx = build.Context{Compiler: "gc", GOPATH: gopath}
 
-		expected := path.Join(gopathOne, "src", "github.com", "fake", "uninstalledlibrary")
+		expected := filepath.Join(gopathOne, "src", "github.com", "fake", "uninstalledlibrary")
 		actual := repo.Dir()
 		if actual != expected {
 			t.Errorf("expected Dir to be %v but it was %v", expected, actual)
@@ -91,7 +91,7 @@ func withDummyBuildContextMultipleGopath(t *testing.T, testFunc func(string, str
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = os.MkdirAll(path.Join(fakeGoPathTwo, "src", "github.com", "fake", "library"), 0777); err != nil {
+	if err = os.MkdirAll(filepath.Join(fakeGoPathTwo, "src", "github.com", "fake", "library"), 0777); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
* handle an error I was ignoring before
* TIL that path list separators vary by platform